### PR TITLE
fix: modified the dependencies install from a requeriments.txt to uv in the CI pipeline

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -23,10 +23,9 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install Dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
+    - name: Install uv
+      run: pip install uv
+    - name: Install dependencies
+      run: uv sync
     - name: Run Tests
-      run: |
-        python manage.py test
+      run: uv run python manage.py test


### PR DESCRIPTION
The CI workflow was installing the dependencies using `pip install -r requirements.txt`, but the project uses `uv` with `pyproject.toml` and `uv.lock`.

The problem was that every time a pull request o push is done, the CI pipeline failed because `uv` is used as package dependency's manager, not a `requirements.txt` file.