### PR TITLE
fix: updated workflows to gather the python scripts from the IshikawaTools folder

### DIFF
--- a/.github/workflows/histogram.yml
+++ b/.github/workflows/histogram.yml
@@ -28,6 +28,7 @@ jobs:
           pip install requests matplotlib
 
       - name: Run issues histogram script
+        working-directory: ./IshikawaTools
         env:
           HISTOGRAM_TOKEN: ${{ secrets.HISTOGRAM_TOKEN }}
         run: python histogram.py

--- a/.github/workflows/pareto.yml
+++ b/.github/workflows/pareto.yml
@@ -37,6 +37,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install pandas matplotlib
     - name: get graphics
+      working-directory: ./IshikawaTools
       run: |
         python chart.py
     - name: Upload chart

--- a/.github/workflows/runchart.yml
+++ b/.github/workflows/runchart.yml
@@ -3,6 +3,7 @@ name: Run Chart Action
 on:  
   schedule:
     - cron: "0 3 * * 1"   # every monday at 3:00
+  workflow_dispatch:
   #push:
   #  branches: master
 
@@ -16,7 +17,7 @@ jobs:
       issues: read
   
     steps:
-      - name: Cechout repo
+      - name: Checkout repo
         uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
@@ -39,7 +40,7 @@ jobs:
   
       - name: Run script
         working-directory: ./IshikawaTools
-        
+
         run: git pull && python ./runchart.py
 
       - name: Commit and Push changes


### PR DESCRIPTION
Updated the workflows to gather the python scripts from the Ishikawa Tools folder.

# Fixes

* Modified workflows files to gather the python scripts from the Ishikawa Tools folder.
* Modified `runchart` workflow to be able to manually trigger it.

<img width="1843" height="870" alt="imagen" src="https://github.com/user-attachments/assets/2e9959a2-c809-4c8f-ae72-51d8c5cab5bd" />
