### PR TITLE
feat(support): added help center and improved/unified design for privacy policy and terms of service

### DIFF
--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
-from .views import SignUpView, terms_of_service, privacy_policy
+from .views import SignUpView, terms_of_service, privacy_policy, help_center
 
 urlpatterns = [
     path("signup/", SignUpView.as_view(), name="signup"),
     path("terms-of-service/", terms_of_service, name="terms_of_service"),
     path("privacy-policy/", privacy_policy, name="privacy_policy"),
+    path('help-center/', help_center, name='help_center'),
 ]

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -5,6 +5,7 @@ urlpatterns = [
     path("signup/", views.SignUpView.as_view(), name="signup"),
     path("terms-of-service/", views.terms_of_service, name="terms_of_service"),
     path("privacy-policy/", views.privacy_policy, name="privacy_policy"),
+    path("help-center/", views.help_center, name="help_center"),
     path('password-reset/', views.password_reset, name='password_reset'),
     path('password-reset/done/', views.password_reset_done, name='password_reset_done'),
     path('password-reset-confirm/<uidb64>/<token>/', views.password_reset_confirm, name='password_reset_confirm'),

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -21,6 +21,7 @@ def privacy_policy(request):
 
 def help_center(request):
     return render(request, 'registration/help_center.html')
+
 password_reset = auth_views.PasswordResetView.as_view(
     template_name='registration/password_reset_form.html',
     success_url=reverse_lazy('password_reset_done')

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -18,3 +18,6 @@ def terms_of_service(request):
 
 def privacy_policy(request):
     return render(request, "registration/privacy_policy.html")
+
+def help_center(request):
+    return render(request, 'registration/help_center.html')

--- a/app/templates/components/footer.html
+++ b/app/templates/components/footer.html
@@ -2,9 +2,9 @@
     <div class="max-w-7xl mx-auto px-6 flex flex-col md:flex-row justify-between items-center gap-4">
         <p class="text-slate-500 dark:text-slate-400 text-sm">&copy 2026 StreamSync Inc. All rights reserved.</p>
         <div class="flex gap-6 text-sm text-slate-500 dark:text-slate-400">
-            <a class="hover:text-primary" href="#">Privacy Policy</a>
-            <a class="hover:text-primary" href="#">Terms of Service</a>
-            <a class="hover:text-primary" href="#">Help Center</a>
+            <a class="hover:text-primary transition-colors" href="{% url 'privacy_policy' %}">Privacy Policy</a>
+            <a class="hover:text-primary transition-colors" href="{% url 'terms_of_service' %}">Terms of Service</a>
+            <a class="hover:text-primary transition-colors" href="{% url 'help_center' %}">Help Center</a>
         </div>
     </div>
 </footer>

--- a/app/templates/pages/home.html
+++ b/app/templates/pages/home.html
@@ -248,14 +248,12 @@
                                 <span class="font-bold">StreamSync</span>
                             </div>
                             <div class="flex flex-wrap justify-center gap-8">
-                                <a class="text-sm text-slate-500 hover:text-primary transition-colors" href="#">Privacy
+                                <a class="text-sm text-slate-500 hover:text-primary transition-colors" href="{% url 'privacy_policy' %}">Privacy
                                     Policy</a>
-                                <a class="text-sm text-slate-500 hover:text-primary transition-colors" href="#">Terms of
+                                <a class="text-sm text-slate-500 hover:text-primary transition-colors" href="{% url 'terms_of_service' %}">Terms of
                                     Service</a>
-                                <a class="text-sm text-slate-500 hover:text-primary transition-colors" href="#">Help
+                                <a class="text-sm text-slate-500 hover:text-primary transition-colors" href="{% url 'help_center' %}">Help
                                     Center</a>
-                                <a class="text-sm text-slate-500 hover:text-primary transition-colors"
-                                    href="#">Contact</a>
                             </div>
                             <div class="flex gap-4">
                                 <a class="text-slate-400 hover:text-white transition-colors" href="#">

--- a/app/templates/registration/help_center.html
+++ b/app/templates/registration/help_center.html
@@ -1,0 +1,50 @@
+{% extends "base/initial.html" %}
+
+{% block content %}
+<div class="min-h-[calc(100vh-80px)] bg-slate-50 dark:bg-background-dark px-4 py-8">
+    <div class="max-w-3xl mx-auto bg-white dark:bg-[#1e293b] p-8 rounded-2xl shadow-xl border border-slate-200 dark:border-slate-800 animate-fade-in-up">
+
+        <div class="text-center mb-10">
+            <div class="inline-flex items-center justify-center w-16 h-16 bg-primary/10 rounded-2xl mb-4">
+                <span class="material-symbols-outlined text-primary text-4xl">support_agent</span>
+            </div>
+            <h1 class="text-3xl font-bold text-slate-900 dark:text-white mb-2">Help Center</h1>
+            <p class="text-slate-500 dark:text-slate-400">Find answers to your questions or contact our support team.</p>
+        </div>
+
+        <div class="space-y-8">
+            <div class="border-l-4 border-primary/30 pl-6 py-1">
+                <h3 class="text-lg font-bold text-slate-900 dark:text-white mb-2 flex items-center gap-2">
+                    <span class="material-symbols-outlined text-primary text-sm">lock_reset</span>
+                    How do I reset my password?
+                </h3>
+                <p class="text-slate-600 dark:text-slate-400">Go to the login page and click on "Forgot Password?". We will send you a reset link to your registered email address. Follow the instructions in the email to set a new secure password.</p>
+            </div>
+
+            <div class="border-l-4 border-primary/30 pl-6 py-1">
+                <h3 class="text-lg font-bold text-slate-900 dark:text-white mb-2 flex items-center gap-2">
+                    <span class="material-symbols-outlined text-primary text-sm">favorite</span>
+                    How does the Favorites list work?
+                </h3>
+                <p class="text-slate-600 dark:text-slate-400">When browsing the content catalog, click the heart icon on any movie or series to add it to your Personal Library. You can view all your saved content in the "My Library" tab at any time.</p>
+            </div>
+
+            <div class="mt-10 bg-blue-50 dark:bg-primary/5 p-8 rounded-2xl text-center border border-blue-100 dark:border-primary/20 shadow-inner">
+                <h3 class="text-xl font-bold text-slate-900 dark:text-white mb-2">Still need help?</h3>
+                <p class="text-slate-600 dark:text-slate-400 mb-6">Our support team is available 24/7 to assist you with any platform issues.</p>
+                <a href="mailto:natpublispam@gmail.com" class="inline-flex items-center gap-2 bg-primary hover:bg-primary/90 text-white font-bold py-3 px-8 rounded-xl transition-all shadow-lg shadow-primary/20">
+                    <span class="material-symbols-outlined">mail</span>
+                    Contact Support
+                </a>
+            </div>
+        </div>
+
+        <div class="mt-3 pt-8 border-t border-slate-100 dark:border-slate-800 text-center">
+            <button onclick="window.history.back()" class="inline-flex items-center gap-2 bg-primary hover:bg-primary/90 text-white font-bold py-3 px-10 rounded-xl hover:scale-105 transition-all shadow-lg shadow-primary/20 cursor-pointer">
+                <span class="material-symbols-outlined">arrow_back</span>
+                Go Back
+            </button>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/registration/privacy_policy.html
+++ b/app/templates/registration/privacy_policy.html
@@ -1,59 +1,73 @@
-{% extends "base/initial.html" %} {% block content %}
+{% extends "base/initial.html" %}
+
+{% block content %}
 <div class="min-h-[calc(100vh-80px)] bg-slate-50 dark:bg-background-dark px-4 py-8">
-    <div class="max-w-3xl mx-auto bg-white dark:bg-[#1e293b] p-8 rounded-2xl shadow-xl border border-slate-200 dark:border-slate-800">
-        
-        <h1 class="text-3xl font-bold text-slate-900 dark:text-white mb-6">Privacy Policy</h1>
-        
-        <div class="prose dark:prose-invert max-w-none">
-            <p class="text-slate-600 dark:text-slate-400">
-                At StreamSync, we take your privacy seriously. This Privacy Policy explains how we collect, use, and protect your information.
-            </p>
-            
-            <h2 class="text-xl font-semibold text-slate-900 dark:text-white mt-6 mb-3">1. Information We Collect</h2>
-            <p class="text-slate-600 dark:text-slate-400">
-                We collect information you provide when creating an account, including your name, email address, and other profile information.
-            </p>
-            
-            <h2 class="text-xl font-semibold text-slate-900 dark:text-white mt-6 mb-3">2. How We Use Your Information</h2>
-            <p class="text-slate-600 dark:text-slate-400">
-                We use your information to provide and improve our services, communicate with you, and personalize your experience.
-            </p>
-            
-            <h2 class="text-xl font-semibold text-slate-900 dark:text-white mt-6 mb-3">3. Data Protection</h2>
-            <p class="text-slate-600 dark:text-slate-400">
-                We implement appropriate security measures to protect your personal information against unauthorized access, alteration, or disclosure.
-            </p>
-            
-            <h2 class="text-xl font-semibold text-slate-900 dark:text-white mt-6 mb-3">4. Third-Party Services</h2>
-            <p class="text-slate-600 dark:text-slate-400">
-                We may share information with third-party service providers who assist us in operating our service, under strict confidentiality obligations.
-            </p>
-            
-            <h2 class="text-xl font-semibold text-slate-900 dark:text-white mt-6 mb-3">5. Cookies</h2>
-            <p class="text-slate-600 dark:text-slate-400">
-                We use cookies to enhance your user experience. You can control cookies through your browser settings.
-            </p>
-            
-            <h2 class="text-xl font-semibold text-slate-900 dark:text-white mt-6 mb-3">6. Your Rights</h2>
-            <p class="text-slate-600 dark:text-slate-400">
-                You have the right to access, correct, or delete your personal information. Contact us to exercise these rights.
-            </p>
-            
-            <h2 class="text-xl font-semibold text-slate-900 dark:text-white mt-6 mb-3">7. Changes to Policy</h2>
-            <p class="text-slate-600 dark:text-slate-400">
-                We may update this policy periodically. We will notify you of any material changes.
-            </p>
-            
-            <h2 class="text-xl font-semibold text-slate-900 dark:text-white mt-6 mb-3">8. Contact</h2>
-            <p class="text-slate-600 dark:text-slate-400">
-                If you have questions about this Privacy Policy, please contact us.
-            </p>
+    <div class="max-w-3xl mx-auto bg-white dark:bg-[#1e293b] p-8 rounded-2xl shadow-xl border border-slate-200 dark:border-slate-800 animate-fade-in-up">
+
+        <div class="text-center mb-10">
+            <div class="inline-flex items-center justify-center w-16 h-16 bg-primary/10 rounded-2xl mb-4">
+                <span class="material-symbols-outlined text-primary text-4xl">shield_with_heart</span>
+            </div>
+            <h1 class="text-3xl font-bold text-slate-900 dark:text-white mb-2">Privacy Policy</h1>
+            <p class="text-slate-500 dark:text-slate-400">At StreamSync, we take your privacy seriously.</p>
         </div>
-        
-        <div class="mt-8 text-center">
-            <a href="{% url 'signup' %}" class="inline-block bg-primary hover:bg-primary/90 text-white font-bold py-3 px-8 rounded-xl transition-all">
-                Back to
-            </a>
+
+        <div class="space-y-8">
+            <p class="text-slate-600 dark:text-slate-400 leading-relaxed italic border-b border-slate-100 dark:border-slate-800 pb-4">
+                This Privacy Policy explains how we collect, use, and protect your information.
+            </p>
+
+            <div class="border-l-4 border-primary/30 pl-6 py-1">
+                <h2 class="text-xl font-bold text-slate-900 dark:text-white mb-2">0. Educational Disclaimer</h2>
+                <p class="text-slate-600 dark:text-slate-400">This platform is a technical demonstration for learning the Django Framework. It is not a commercial entity. All simulated environments are for academic purposes.</p>
+            </div>
+
+            <div class="border-l-4 border-primary/30 pl-6 py-1">
+                <h2 class="text-xl font-bold text-slate-900 dark:text-white mb-2">1. Information we collect</h2>
+                <p class="text-slate-600 dark:text-slate-400">We collect information you provide when creating an account, including your name, email address, and other profile information.</p>
+            </div>
+
+            <div class="border-l-4 border-primary/30 pl-6 py-1">
+                <h2 class="text-xl font-bold text-slate-900 dark:text-white mb-2">2. How we will use Your Information</h2>
+                <p class="text-slate-600 dark:text-slate-400">We will use your information to provide and improve our services, communicate with you, and ensure security.</p>
+            </div>
+
+            <div class="border-l-4 border-primary/30 pl-6 py-1">
+                <h2 class="text-xl font-bold text-slate-900 dark:text-white mb-2">3. Information Sharing</h2>
+                <p class="text-slate-600 dark:text-slate-400">We do not sell your personal information. We may share data with trusted partners to help operate our service.</p>
+            </div>
+
+            <div class="border-l-4 border-primary/30 pl-6 py-1">
+                <h2 class="text-xl font-bold text-slate-900 dark:text-white mb-2">4. Data Security</h2>
+                <p class="text-slate-600 dark:text-slate-400">We implement industry-standard security measures to protect your data from unauthorized access.</p>
+            </div>
+
+            <div class="border-l-4 border-primary/30 pl-6 py-1">
+                <h2 class="text-xl font-bold text-slate-900 dark:text-white mb-2">5. Cookies</h2>
+                <p class="text-slate-600 dark:text-slate-400">We use cookies to enhance your user experience. You can control cookies through your browser settings.</p>
+            </div>
+
+            <div class="border-l-4 border-primary/30 pl-6 py-1">
+                <h2 class="text-xl font-bold text-slate-900 dark:text-white mb-2">6. Your Rights</h2>
+                <p class="text-slate-600 dark:text-slate-400">You have the right to access, correct, or delete your personal information. Contact us to exercise these rights.</p>
+            </div>
+
+            <div class="border-l-4 border-primary/30 pl-6 py-1">
+                <h2 class="text-xl font-bold text-slate-900 dark:text-white mb-2">7. Changes to Policy</h2>
+                <p class="text-slate-600 dark:text-slate-400">We may update this policy periodically. We will notify you of any material changes.</p>
+            </div>
+
+            <div class="border-l-4 border-primary/30 pl-6 py-1">
+                <h2 class="text-xl font-bold text-slate-900 dark:text-white mb-2">8. Contact</h2>
+                <p class="text-slate-600 dark:text-slate-400">If you have questions about this Privacy Policy, please contact us.</p>
+            </div>
+        </div>
+
+        <div class="mt-3 pt-8 border-t border-slate-100 dark:border-slate-800 text-center">
+            <button onclick="window.history.back()" class="inline-flex items-center gap-2 bg-primary hover:bg-primary/90 text-white font-bold py-3 px-10 rounded-xl hover:scale-105 transition-all shadow-lg shadow-primary/20 cursor-pointer">
+                <span class="material-symbols-outlined">arrow_back</span>
+                Acknowledge & Go Back
+            </button>
         </div>
     </div>
 </div>

--- a/app/templates/registration/terms_of_service.html
+++ b/app/templates/registration/terms_of_service.html
@@ -1,49 +1,58 @@
-{% extends "base/initial.html" %} {% block content %}
+{% extends "base/initial.html" %}
+
+{% block content %}
 <div class="min-h-[calc(100vh-80px)] bg-slate-50 dark:bg-background-dark px-4 py-8">
-    <div class="max-w-3xl mx-auto bg-white dark:bg-[#1e293b] p-8 rounded-2xl shadow-xl border border-slate-200 dark:border-slate-800">
-        
-        <h1 class="text-3xl font-bold text-slate-900 dark:text-white mb-6">Terms of Service</h1>
-        
-        <div class="prose dark:prose-invert max-w-none">
-            <p class="text-slate-600 dark:text-slate-400">
-                Welcome to StreamSync. By accessing and using our service, you agree to be bound by these Terms of Service.
-            </p>
-            
-            <h2 class="text-xl font-semibold text-slate-900 dark:text-white mt-6 mb-3">1. Acceptance of Terms</h2>
-            <p class="text-slate-600 dark:text-slate-400">
-                By creating an account or accessing StreamSync, you acknowledge that you have read, understood, and agree to be bound by these terms.
-            </p>
-            
-            <h2 class="text-xl font-semibold text-slate-900 dark:text-white mt-6 mb-3">2. Use of Service</h2>
-            <p class="text-slate-600 dark:text-slate-400">
-                You agree to use StreamSync only for lawful purposes and in accordance with these Terms of Service.
-            </p>
-            
-            <h2 class="text-xl font-semibold text-slate-900 dark:text-white mt-6 mb-3">3. Account Responsibilities</h2>
-            <p class="text-slate-600 dark:text-slate-400">
-                You are responsible for maintaining the confidentiality of your account credentials and for all activities that occur under your account.
-            </p>
-            
-            <h2 class="text-xl font-semibold text-slate-900 dark:text-white mt-6 mb-3">4. Privacy</h2>
-            <p class="text-slate-600 dark:text-slate-400">
-                Your privacy is important to us. Please review our Privacy Policy to understand how we collect and use your information.
-            </p>
-            
-            <h2 class="text-xl font-semibold text-slate-900 dark:text-white mt-6 mb-3">5. Changes to Terms</h2>
-            <p class="text-slate-600 dark:text-slate-400">
-                We reserve the right to modify these terms at any time. Continued use of the service constitutes acceptance of any changes.
-            </p>
-            
-            <h2 class="text-xl font-semibold text-slate-900 dark:text-white mt-6 mb-3">6. Contact</h2>
-            <p class="text-slate-600 dark:text-slate-400">
-                If you have any questions about these Terms of Service, please contact us.
-            </p>
+    <div class="max-w-3xl mx-auto bg-white dark:bg-[#1e293b] p-8 rounded-2xl shadow-xl border border-slate-200 dark:border-slate-800 animate-fade-in-up">
+
+        <div class="text-center mb-10">
+            <div class="inline-flex items-center justify-center w-16 h-16 bg-primary/10 rounded-2xl mb-4">
+                <span class="material-symbols-outlined text-primary text-4xl">gavel</span>
+            </div>
+            <h1 class="text-3xl font-bold text-slate-900 dark:text-white mb-2">Terms of Service</h1>
+            <p class="text-slate-500 dark:text-slate-400">Welcome to StreamSync. Our rules and guidelines.</p>
         </div>
-        
-        <div class="mt-8 text-center">
-            <a href="{% url 'signup' %}" class="inline-block bg-primary hover:bg-primary/90 text-white font-bold py-3 px-8 rounded-xl transition-all">
-                Back to Sign Up
-            </a>
+
+        <div class="space-y-8">
+            <p class="text-slate-600 dark:text-slate-400 mb-6 italic border-b border-slate-100 dark:border-slate-800 pb-4">
+                By accessing and using our service, you agree to be bound by these Terms of Service.
+            </p>
+
+            <div class="border-l-4 border-primary/30 pl-6 py-1">
+                <h2 class="text-xl font-bold text-slate-900 dark:text-white mb-2">1. Acceptance of Terms</h2>
+                <p class="text-slate-600 dark:text-slate-400">By creating an account or accessing StreamSync, you acknowledge that you have read, understood, and agree to be bound by these terms.</p>
+            </div>
+
+            <div class="border-l-4 border-primary/30 pl-6 py-1">
+                <h2 class="text-xl font-bold text-slate-900 dark:text-white mb-2">2. Use of Service</h2>
+                <p class="text-slate-600 dark:text-slate-400">You agree to use the service only for lawful purposes and in accordance with these Terms.</p>
+            </div>
+
+            <div class="border-l-4 border-primary/30 pl-6 py-1">
+                <h2 class="text-xl font-bold text-slate-900 dark:text-white mb-2">3. Account Security</h2>
+                <p class="text-slate-600 dark:text-slate-400">You are responsible for maintaining the confidentiality of your credentials and for all activities that occur under your account.</p>
+            </div>
+
+            <div class="border-l-4 border-primary/30 pl-6 py-1">
+                <h2 class="text-xl font-bold text-slate-900 dark:text-white mb-2">4. Privacy</h2>
+                <p class="text-slate-600 dark:text-slate-400">Your privacy is important to us. Please review our Privacy Policy to understand how we collect and use your information.</p>
+            </div>
+
+            <div class="border-l-4 border-primary/30 pl-6 py-1">
+                <h2 class="text-xl font-bold text-slate-900 dark:text-white mb-2">5. Changes to Terms</h2>
+                <p class="text-slate-600 dark:text-slate-400">We reserve the right to modify these terms at any time. Continued use of the service constitutes acceptance of any changes.</p>
+            </div>
+
+            <div class="border-l-4 border-primary/30 pl-6 py-1">
+                <h2 class="text-xl font-bold text-slate-900 dark:text-white mb-2">6. Contact</h2>
+                <p class="text-slate-600 dark:text-slate-400">If you have any questions about these Terms of Service, please contact us.</p>
+            </div>
+        </div>
+
+        <div class="mt-3 pt-8 border-t border-slate-100 dark:border-slate-800 text-center">
+            <button onclick="window.history.back()" class="inline-flex items-center gap-2 bg-primary hover:bg-primary/90 text-white font-bold py-3 px-10 rounded-xl hover:scale-105 transition-all shadow-lg shadow-primary/20 cursor-pointer">
+                <span class="material-symbols-outlined">done_all</span>
+                Accept & Go Back
+            </button>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## What has been done

It has implemented the Help Center module, where users can see frequent questions and the response from the team. Now there are only 2 FAQs, but it's intended to grow in the future.

Moreover, it has been added the corresponding links in the HTMLs from the footer and home page to be able to access these pages. 

Additionally, it has been updated with a design to make it a little more attractive visually and added some simple iconography to better understand what each of the support modules is intended to represent.

## Changes

- Added the Help Center page with specialized support contact section.
- Unified the styling for Privacy Policy and Terms of Service.
- Standardized buttons and icons across all these support pages.
- Updated footer links and URL routing to include the links to these support pages.

## Images

### **Privacy Policy**

<img width="458" height="777" alt="image" src="https://github.com/user-attachments/assets/f9912332-d9a9-43d4-8fa8-1e23cfdad32c" />

### **Terms of service**

<img width="660" height="870" alt="image" src="https://github.com/user-attachments/assets/7cf7abe2-8181-4f64-98d6-afce3c46b458" />

### **Help center**

<img width="1218" height="874" alt="image" src="https://github.com/user-attachments/assets/c5d374cd-6a5e-432b-984e-d0c47dfd8015" />

