### PR TITLE
feat(platform-navigation): added a simulated redirection page to plat…

### DIFF
--- a/app/templates/pages/content_view.html
+++ b/app/templates/pages/content_view.html
@@ -76,11 +76,11 @@
         <div class="flex flex-wrap gap-4 pt-4">
           {% for p in content.platforms_data %}
             {% if p.state == 'available' %}
-            <button
-              class="bg-[#256af4] hover:bg-blue-500 text-white px-10 py-4 rounded-xl font-bold flex items-center gap-3 shadow-lg shadow-primary/30 active:scale-95 transition-all">
+            <a href="{% url 'app:redirect_simulation' %}?platform={{ p.name|urlencode }}&title={{ content.title|urlencode }}"
+               class="bg-[#256af4] hover:bg-blue-500 text-white px-10 py-4 rounded-xl font-bold flex items-center gap-3 shadow-lg shadow-primary/30 active:scale-95 transition-all decoration-none">
               <span class="material-symbols-outlined" style="font-variation-settings: 'FILL' 1;">play_arrow</span>
               {{ p.name }}
-            </button>
+            </a>
             {% else %}
             <button disabled
               class="bg-slate-500/50 text-slate-300 px-10 py-4 rounded-xl font-bold flex items-center gap-3 cursor-not-allowed transition-all">

--- a/app/templates/pages/redirect_simulation.html
+++ b/app/templates/pages/redirect_simulation.html
@@ -1,0 +1,64 @@
+{% extends "base/base.html" %}
+{% load i18n %}
+
+{% block title %}StreamSync - {% trans "Leaving StreamSync" %}{% endblock %}
+
+{% block content %}
+    <div class="flex flex-col items-center justify-center min-h-[65vh] px-4 text-center">
+        <div class="max-w-md w-full bg-[#0f172a]/90 border border-white/10 p-8 rounded-[2.5rem] shadow-[0_0_50px_rgba(0,0,0,0.7)] backdrop-blur-xl">
+
+            <div class="relative size-20 rounded-full bg-primary/10 flex items-center justify-center mx-auto mb-6">
+                <span class="material-symbols-outlined text-4xl text-primary animate-pulse">open_in_new</span>
+                <div class="absolute inset-0 rounded-full border-2 border-primary/20 border-t-primary animate-spin"></div>
+            </div>
+
+            <h2 class="text-2xl font-bold text-white mb-2">
+                {% trans "Leaving StreamSync" %}
+            </h2>
+
+            <p class="text-slate-400 text-sm mb-6">
+                {% trans "You are being redirected to an external site." %}
+            </p>
+
+            <div class="bg-slate-900/60 border border-white/5 rounded-2xl p-5 mb-6 flex flex-col gap-3 text-left">
+                <div>
+                    <span class="text-[10px] text-slate-500 uppercase font-bold tracking-wider block mb-1">{% trans "Content to visit" %}</span>
+                    <span class="text-white font-semibold text-base block truncate">"{{ content_title }}"</span>
+                </div>
+                <div class="border-t border-white/5 pt-2 flex justify-between items-center">
+                    <div>
+                        <span class="text-[10px] text-slate-500 uppercase font-bold tracking-wider block">{% trans "External website from" %}</span>
+                        <span class="text-primary font-black text-lg block">{{ platform_name }}</span>
+                    </div>
+                </div>
+            </div>
+
+            <button id="auto-return-btn" onclick="window.history.back();"
+                    class="inline-flex items-center justify-center gap-2 bg-primary hover:bg-primary/90 text-white font-bold px-6 py-3 rounded-xl transition-all shadow-lg shadow-primary/20 active:scale-95 w-full">
+                <span class="material-symbols-outlined text-lg">arrow_back</span>
+                <span>{% trans "Returning to Previous Page" %} (<span id="countdown">10</span>s)</span>
+            </button>
+        </div>
+    </div>
+{% endblock %}
+
+{% block extra_scripts %}
+<script>
+    document.addEventListener("DOMContentLoaded", function() {
+        let timeLeft = 10;
+        const countdownElement = document.getElementById("countdown");
+
+        const timer = setInterval(function() {
+            timeLeft--;
+            if (countdownElement) {
+                countdownElement.textContent = timeLeft;
+            }
+
+            if (timeLeft <= 0) {
+                clearInterval(timer);
+                window.history.back();
+            }
+        }, 1000);
+    });
+</script>
+{% endblock %}

--- a/app/urls.py
+++ b/app/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
     path('search/', views.search, name='search'),
     path('redirect/',views.login_redirect, name='login_redirect'),
     path('content/<str:ctype>/<str:cid>/', views.content_detail, name='content_detail'),
+    path('content/redirect-simulation/', views.redirect_simulation, name='redirect_simulation'),
     path('content/<str:ctype>/<str:cid>/update-status/', views.update_status, name='update_status'),
     path('content/<str:ctype>/<str:cid>/toggle-favorite/', views.toggle_favorite, name='toggle_favorite'),
     path('content/<str:ctype>/<str:cid>/add-to-list/<int:list_id>/', views.add_to_list, name='add_to_list'),
@@ -23,7 +24,6 @@ urlpatterns = [
     path('onboarding-complete/', views.onboarding_complete, name='onboarding_complete'),
     path('delete_account/', views.delete_account, name='delete_account'),
     path('dashboard/direction/', views.direction_dashboard, name='direction_dashboard'),
-    
     path('api/notifications/mark-seen/', views.mark_notification_seen, name='mark_notification_seen'),
     path('dashboard/manager/', views.manager_dashboard, name='manager_dashboard'),
     path('content/<str:ctype>/<int:cid>/', views.content_detail, name='content_detail'),

--- a/app/views.py
+++ b/app/views.py
@@ -1228,3 +1228,13 @@ def manager_dashboard(request):
         'top_content_values': json.dumps(top_content_values),
         'filters': filters_data
     })
+
+
+def redirect_simulation(request):
+    platform_name = request.GET.get('platform', 'External Platform')
+    content_title = request.GET.get('title', 'Selected Content')
+
+    return render(request, 'pages/redirect_simulation.html', {
+        'platform_name': platform_name,
+        'content_title': content_title,
+    })


### PR DESCRIPTION
## What has been done

It has been implemented a redirection page to handle a simulated external platform routing. It is being used to give some functionality to the buttons from the platform from a specific content view detail.

## Changes
- Added a redirection page to simulate some functionality once the user press the button to visit a specific content from a specific website.
- Added a countdown to return to the previous page of 10s if the user doesn't press any button in that time.
- Added the `redirect_simulation.html` to handle all this new feature.

# Images

<img width="1615" height="823" alt="image" src="https://github.com/user-attachments/assets/bf59bdb1-8e09-4ff2-9958-6a670dedfb48" />
